### PR TITLE
Adds the VCA CI scripts to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,29 @@
 FROM vcatechnology/arch:latest
 MAINTAINER VCA Technology <developers@vcatechnology.com>
 
+# install development packages
 RUN pacman --noconfirm --needed -S \
   make \
   cmake \
   automake \
   git \
   python \
-  sudo
+  sudo \
+  && pacman --noconfirm -Scc
+
+# grab the VCA CI scripts
+RUN pacman --noconfirm --needed -S wget tar xz && \
+  wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
+  tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
+  rm vca-tool-chain-ci-scripts-latest.tar.xz && \
+  pacman -Rsn --noconfirm wget tar xz && \
+  pacman --noconfirm -Scc
 
 # create a build-server user with sudo permissions & no password
 RUN useradd -ms /bin/bash build-server && \
     echo "build-server ALL=(root) NOPASSWD:ALL" | tee -a /etc/sudoers.d/build-server && \
     echo "#includedir /etc/sudoers.d" >> /etc/sudoers && \
     chmod 0440 /etc/sudoers.d/build-server
-
-# create a /builds folder with acceptable permissions using acl
-RUN mkdir /builds && chmod a+rwx /builds && setfacl -dRm u::rwX,g::rwX,o::rwX /builds
 
 # set the build-server user as default
 WORKDIR /builds


### PR DESCRIPTION
The CI scripts provide easy ways to set up the Docker image in the `.gitlab-ci.yml` files.