### PR TITLE
Dont install/remove tar or xz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ RUN pacman --noconfirm --needed -S \
   && pacman --noconfirm -Scc
 
 # grab the VCA CI scripts
-RUN pacman --noconfirm --needed -S wget tar xz && \
+RUN pacman --noconfirm --needed -S wget && \
   wget https://tool-chain.vcatechnology.com/release/vca-tool-chain-ci-scripts-latest.tar.xz && \
   tar -Jxf vca-tool-chain-ci-scripts-latest.tar.xz -C / && \
   rm vca-tool-chain-ci-scripts-latest.tar.xz && \
-  pacman -Rsn --noconfirm wget tar xz && \
+  pacman -Rsn --noconfirm wget && \
   pacman --noconfirm -Scc
 
 # create a build-server user with sudo permissions & no password


### PR DESCRIPTION
tar & xz dependencies are already available. (see https://hub.docker.com/r/vcatechnology/arch-ci/builds/bu5gedfe54dtcnvsw4bdhuc/)
also removing tar/xz causes errors:

```
sudo pacman -Rsn xz
checking dependencies...
error: failed to prepare transaction (could not satisfy dependencies)
:: libarchive: removing xz breaks dependency 'xz'
:: libsystemd: removing xz breaks dependency 'xz'
:: libxml2: removing xz breaks dependency 'xz'
```

```
sudo pacman -Rsn tar
checking dependencies...
error: failed to prepare transaction (could not satisfy dependencies)
:: libtool: removing tar breaks dependency 'tar'
```
