### PR TITLE
Create mnt builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN useradd -ms /bin/bash build-server && \
     chmod 0440 /etc/sudoers.d/build-server
 
 # Set the build-server user as default
+RUN mkdir /mnt/builds
 WORKDIR /mnt/builds
 RUN chown build-server:build /mnt/builds
 USER build-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,5 @@ RUN useradd -ms /bin/bash build-server && \
 # Set the build-server user as default
 RUN mkdir /mnt/builds
 WORKDIR /mnt/builds
-RUN chown build-server:build /mnt/builds
+RUN chown build-server:build-server /mnt/builds
 USER build-server


### PR DESCRIPTION
Fixes so that the docker image enters the correct directory '/mnt/builds' when started with docker run