### PR TITLE
Install rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN vca-install-package \
   git \
   python \
   sudo \
-  openssh
+  openssh \
+  rsync
 
 # Grab the VCA CI scripts
 RUN vca-install-package wget && \


### PR DESCRIPTION
We need rsync for the vca-tool-chain-upload script. It has changed from scp